### PR TITLE
Fixed prblem running operations on Linux and MacOS

### DIFF
--- a/internal/models/app.go
+++ b/internal/models/app.go
@@ -27,7 +27,7 @@ func (app *App) ConfigureLogging(logging Log) {
 	}
 
 	// if the log level is set to debug, add the caller to the messages
-	if ll == log.DebugLevel {
+	if ll == log.TraceLevel {
 		app.Logger.SetReportCaller(true)
 	}
 

--- a/internal/util/build_command.go
+++ b/internal/util/build_command.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"regexp"
+	"runtime"
+)
+
+// BuildCommand builds up the command to be used, depending on the OS in use
+// This is required so that on Windows the command is prepended with "cmd /C" and
+// the arguments need to be split up into a slice so that they are passed to the exec.Command
+// method
+func BuildCommand(command string, arguments string) (string, []string) {
+
+	var cmd string
+	var args []string
+
+	// split the argument string into a slice
+	// this uses a regular expression to split up the arguments using space as a delimeter
+	// However it will not split on a space that is contained within quotes (double or single)
+	re := regexp.MustCompile(`[^\s"']+|"([^"]*)"|'([^']*)`)
+	args = re.FindAllString(arguments, -1)
+
+	// if running on Windows then the cmd needs to be set to "cmd" and /C and the command prepended
+	// to the args slice, otherwise set cmd to command
+	if runtime.GOOS == "windows" {
+		cmd = "cmd"
+		args = append([]string{"/C", command}, args...)
+	} else {
+		cmd = command
+	}
+
+	return cmd, args
+}

--- a/internal/util/build_command_test.go
+++ b/internal/util/build_command_test.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestBuildCommand(t *testing.T) {
+
+	// create test table to iterate over
+	tables := []struct {
+		platform  string
+		command   string
+		arguments string
+		test      string
+		count     int
+	}{
+		{
+			"windows",
+			"dotnet",
+			"new -i .",
+			"cmd",
+			5,
+		},
+		{
+			"windows",
+			"echo",
+			`"Hello Golang"`,
+			"cmd",
+			3,
+		},
+		{
+			"linux",
+			"dotnet",
+			"new -i .",
+			"dotnet",
+			3,
+		},
+	}
+
+	// iterate around the test tables and perform the tests
+	for _, table := range tables {
+
+		// run if the OS is the same as the platform
+		if runtime.GOOS == table.platform {
+
+			// get the cmd and args from the build command
+			cmd, args := BuildCommand(table.command, table.arguments)
+
+			// check that the command
+			if cmd != table.test {
+				t.Error("Command has not been sect correctly")
+			}
+
+			if len(args) != table.count {
+				t.Error("Number of arguments is incorrect")
+			}
+		}
+
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,7 +233,7 @@ func (config *Config) WriteCmdLog(path string, cmd string) error {
 	}
 
 	// get a reference to the file, either to create or append to the file
-	f, err := os.OpenFile(config.Self.CmdLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(config.Self.CmdLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -53,7 +53,7 @@ func (i *Interactive) Run() error {
 	}
 
 	// write the data out to the file
-	err = ioutil.WriteFile(path, data, 0)
+	err = ioutil.WriteFile(path, data, 0666)
 
 	// output information about what to run next
 	helpText := fmt.Sprintf(`To scaffold the new projects, run the following command


### PR DESCRIPTION
There was an issue where the scaffold commands were not being executed properly on MacOS and Linux. This was down to the way in which the arguments were being sent in.

This was caused by the arguments being sent in as a string, which worked fine on Windows, however on the other platforms this needed to be sent in as a slice. The code has been updated to include a regular expression that splits the arguments up using spaced as a delimiter, except when the space is in quotes. 

Other changes:
- Fix file permissions on written out var file
- Calling function is only output in logs when Trace level is used.