### PR TITLE
[3352] Create new project with command line options

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,8 +12,8 @@ env:
   OUTPUT_DOCS_DIR: "{{.OUTPUT_DIR}}/docs"
   OUTPUT_DOCS_PDF_DIR: "{{.OUTPUT_DOCS_DIR}}/pdf"
   OUTPUT_DOCS_MD_DIR: "{{.OUTPUT_DOCS_DIR}}/md"
-  BIN_DIR: bin/
-  WORKING_DIR: .
+  BIN_DIR: '{{ .BIN_DIR | default "bin" }}'
+  WORKING_DIR: '{{ .WORKING_DIR | default "projects" }}'
 
 vars:
   REPORT_OUTPUT: report.xml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,7 +79,7 @@ tasks:
       - task: test:setup
       - chmod +x {{.BIN_DIR}}/*
       - "{{.BIN_DIR}}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{.WORKING_DIR}} --binarycmd {{.BIN_DIR}}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
-      - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
+      - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test_report.xml"
       - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - go mod tidy
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,14 +4,8 @@ version: '3'
 
 env:
   BUILDNUMBER: '{{ .BUILDNUMBER | default "100.98.99" }}'
-  DOCS_DIR: docs/
-  OUTPUT_DIR: outputs
-  OUTPUT_TEST_DIR: "{{.OUTPUT_DIR}}/tests"
-  OUTPUT_INTTEST_DIR: "{{.OUTPUT_DIR}}/integration_tests"
-  OUTPUT_BIN_DIR: "{{.OUTPUT_DIR}}/bin"
-  OUTPUT_DOCS_DIR: "{{.OUTPUT_DIR}}/docs"
-  OUTPUT_DOCS_PDF_DIR: "{{.OUTPUT_DOCS_DIR}}/pdf"
-  OUTPUT_DOCS_MD_DIR: "{{.OUTPUT_DOCS_DIR}}/md"
+  DOCS_DIR: '{{ .DOCS_DIR | default "docs/" }}'
+  OUTPUT_DIR: '{{ .OUTPUT_DIR | default "outputs" }}'
   BIN_DIR: '{{ .BIN_DIR | default "bin" }}'
   WORKING_DIR: '{{ .WORKING_DIR | default "projects" }}'
 
@@ -19,6 +13,12 @@ vars:
   REPORT_OUTPUT: report.xml
   INTEGRATION_REPORT_OUTPUT: integration_report.xml
   COVERAGE_REPORT: coverage.xml
+  OUTPUT_TEST_DIR: "{{.OUTPUT_DIR}}/tests"
+  OUTPUT_INTTEST_DIR: "{{.OUTPUT_DIR}}/integration_tests"
+  OUTPUT_BIN_DIR: "{{.OUTPUT_DIR}}/bin"
+  OUTPUT_DOCS_DIR: "{{.OUTPUT_DIR}}/docs"
+  OUTPUT_DOCS_PDF_DIR: "{{.OUTPUT_DOCS_DIR}}/pdf"
+  OUTPUT_DOCS_MD_DIR: "{{.OUTPUT_DOCS_DIR}}/md"
 
 # dotenv: ['.env']
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,13 +7,19 @@ env:
   DOCS_DIR: docs/
   OUTPUT_DIR: outputs
   OUTPUT_TEST_DIR: "{{.OUTPUT_DIR}}/tests"
+  OUTPUT_INTTEST_DIR: "{{.OUTPUT_DIR}}/integration_tests"
   OUTPUT_BIN_DIR: "{{.OUTPUT_DIR}}/bin"
   OUTPUT_DOCS_DIR: "{{.OUTPUT_DIR}}/docs"
   OUTPUT_DOCS_PDF_DIR: "{{.OUTPUT_DOCS_DIR}}/pdf"
   OUTPUT_DOCS_MD_DIR: "{{.OUTPUT_DOCS_DIR}}/md"
 
+  # Declare env vars for the location of the necessary binaries
+  BIN_DIR: bin/
+  WORKING_DIR: .
+
 vars:
   REPORT_OUTPUT: report.xml
+  INTEGRATION_REPORT_OUTPUT: integration_report.xml
   COVERAGE_REPORT: coverage.xml
 
 # dotenv: ['.env']
@@ -33,14 +39,20 @@ tasks:
   test:
     desc: Run tests and reports
     cmds:
-      - cmd: mkdir -p {{.OUTPUT_TEST_DIR}}
       - task: test:execute
       - task: test:reports
       
+  test:setup:
+    desc: Setup the tests
+    cmds:
+      - cmd: mkdir -p {{.OUTPUT_TEST_DIR}}
+      - cmd: mkdir -p {{.OUTPUT_INTTEST_DIR}}
+      - go get github.com/jstemmer/go-junit-report
+
   test:execute:
     desc: Run Unit Tests
     cmds:
-      - go get github.com/jstemmer/go-junit-report
+      - task: test:setup
       - go get github.com/axw/gocov/gocov
       - go get github.com/AlekSi/gocov-xml
       - go test ./... -v | go-junit-report > {{.OUTPUT_TEST_DIR}}/{{.REPORT_OUTPUT}}
@@ -59,9 +71,23 @@ tasks:
       - sh: test -f {{.OUTPUT_TEST_DIR}}/cover.out
         msg: "Coverage report does not exist: {{.OUTPUT_TEST_DIR}}/cover.out"
 
+  # Run the integration tests using the binary that can be found in the BIN_DIR
+  # The test binary does not like to use the pipe symbol, so the test results are redirected to a text file
+  # and then output to go-junit-report so that the main report file can be generated
+  # The temporary report file is then deleted.
+  test:integration:
+    desc: Run Integration tests
+    cmds:
+      - task: test:setup
+      - "{{ .BIN_DIR }}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{ .WORKING_DIR }} --binarycmd {{ .BIN_DIR }}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
+      - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
+      - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
+      - go mod tidy
+
   compile:cmd:
     cmds:
       - go build -ldflags "-X github.com/amido/stacks-cli/cmd.version={{.BUILDNUMBER}}" -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}}
+      - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c ${PWD}/testing/integration/...
   
     env:
       GOOS: '{{ .PLATFORM_OS }}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,9 +84,8 @@ tasks:
 
   compile:cmd:
     cmds:
-      - ls -l
       - go build -ldflags "-X github.com/amido/stacks-cli/cmd.version={{.BUILDNUMBER}}" -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}}
-      - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c testing/integration/...
+      - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c github.com/amido/stacks-cli/testing/integration/...
   
     env:
       GOOS: '{{ .PLATFORM_OS }}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,15 +79,18 @@ tasks:
     desc: Run Integration tests
     cmds:
       - task: test:setup
-      - "{{ .BIN_DIR }}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{ .WORKING_DIR }} --binarycmd {{ .BIN_DIR }}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
+      - "{{.BIN_DIR}}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{.WORKING_DIR}} --binarycmd {{.BIN_DIR}}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
       - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - go mod tidy
+    env:
+      BIN_DIR: '{{.BIN_DIR}}'
+      WORKING_DIR: '{{.WORKING_DIR}}'
 
   compile:cmd:
     cmds:
       - go build -ldflags "-X github.com/amido/stacks-cli/cmd.version={{.BUILDNUMBER}}" -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}}
-      - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c ${PWD}/testing/integration/...
+      - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c testing/integration/...
   
     env:
       GOOS: '{{ .PLATFORM_OS }}'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,6 +77,7 @@ tasks:
     desc: Run Integration tests
     cmds:
       - task: test:setup
+      - ls -l {{.BIN_DIR}}
       - "{{.BIN_DIR}}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{.WORKING_DIR}} --binarycmd {{.BIN_DIR}}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
       - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,6 +84,7 @@ tasks:
 
   compile:cmd:
     cmds:
+      - ls -l
       - go build -ldflags "-X github.com/amido/stacks-cli/cmd.version={{.BUILDNUMBER}}" -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}}
       - go test -tags integration -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-inttest-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}} -c testing/integration/...
   

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,8 +12,6 @@ env:
   OUTPUT_DOCS_DIR: "{{.OUTPUT_DIR}}/docs"
   OUTPUT_DOCS_PDF_DIR: "{{.OUTPUT_DOCS_DIR}}/pdf"
   OUTPUT_DOCS_MD_DIR: "{{.OUTPUT_DOCS_DIR}}/md"
-
-  # Declare env vars for the location of the necessary binaries
   BIN_DIR: bin/
   WORKING_DIR: .
 
@@ -83,9 +81,6 @@ tasks:
       - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
       - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - go mod tidy
-    env:
-      BIN_DIR: '{{.BIN_DIR}}'
-      WORKING_DIR: '{{.WORKING_DIR}}'
 
   compile:cmd:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,7 +77,7 @@ tasks:
     desc: Run Integration tests
     cmds:
       - task: test:setup
-      - ls -l {{.BIN_DIR}}
+      - chmod +x {{.BIN_DIR}}/*
       - "{{.BIN_DIR}}/stacks-cli-{{OS}}-inttest-amd64-{{.BUILDNUMBER}} --test.v --projectdir {{.WORKING_DIR}} --binarycmd {{.BIN_DIR}}/stacks-cli-{{OS}}-amd64-{{.BUILDNUMBER}} > {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"
       - "cat {{.OUTPUT_TEST_DIR}}/integration_report.temp.out | go-junit-report > {{.OUTPUT_TEST_DIR}}/integration_test.xml"
       - "rm {{.OUTPUT_TEST_DIR}}/integration_report.temp.out"

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -48,7 +48,6 @@ stages:
             task docs
         env:
           BUILDNUMBER: $(Build.BuildNumber)
-          OUTPUT_DIR: $(Build.SourcesDirectory)/outputs
 
       # Upload the tests and the coverage
       - task: PublishTestResults@2

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -85,6 +85,12 @@ stages:
 
       steps:
 
+      # Ensure using correct version of Golang
+      - task: GoTool@0
+        displayName: Setting GO Version
+        inputs:
+          version: ${{ variables.GoVersion }}      
+
       # Download the StacksCLI and the integration_tests
       - task: DownloadPipelineArtifact@2
         inputs: 

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -110,6 +110,7 @@ stages:
         env:
           BIN_DIR: $(Build.ArtifactStagingDirectory)/bin
           WORKING_DIR: $(Agent.TempDirectory)/projects
+          BUILDNUMBER: $(Build.BuildNumber)
 
       # Upload the integration test results
       - task: PublishTestResults@2

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -89,7 +89,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs: 
           artifact: StacksCLI
-          path: bin
+          path: $(Build.ArtifactStagingDirectory)/bin
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3
@@ -108,8 +108,7 @@ stages:
           script: |
             task test:integration
         env:
-          BIN_DIR: bin/
-          WORKING_DIR: projects/
+          BIN_DIR: $(Build.ArtifactStagingDirectory)/bin
           BUILDNUMBER: $(Build.BuildNumber)
 
       # Upload the integration test results

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -81,7 +81,7 @@ stages:
 
     jobs:
     
-    - job: Execute Functional Tests
+    - job: IntegrationTests
 
       steps:
 

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -55,6 +55,7 @@ stages:
         inputs:
           testResultsFormat: JUnit
           testResultsFiles: $(Build.SourcesDirectory)/outputs/tests/report.xml
+          testRunTitle: UnitTests
 
       - task: PublishCodeCoverageResults@1 
         inputs:
@@ -124,6 +125,7 @@ stages:
         inputs:
           testResultsFormat: JUnit
           testResultsFiles: $(Build.SourcesDirectory)/outputs/tests/integration_test_report.xml
+          testRunTitle: IntegrationTests
 
   - stage: Release
     dependsOn: Build

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -77,7 +77,7 @@ stages:
 
   - stage: Integration Tests
     dependsOn: Build
-    condition: and(succeeded())
+    condition: succeeded()
 
     jobs:
     

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -89,7 +89,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs: 
           artifact: StacksCLI
-          path: $(Build.ArtifactStagingDirectory)/bin
+          path: bin
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3
@@ -108,8 +108,8 @@ stages:
           script: |
             task test:integration
         env:
-          BIN_DIR: $(Build.ArtifactStagingDirectory)/bin
-          WORKING_DIR: $(Agent.TempDirectory)/projects
+          BIN_DIR: bin/
+          WORKING_DIR: projects/
           BUILDNUMBER: $(Build.BuildNumber)
 
       # Upload the integration test results

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -102,7 +102,7 @@ stages:
 
       # Run the integration tests
       - task: Bash@3
-        displayName: Build & Test
+        displayName: Execute Tests
         inputs:
           targetType: inline
           script: |

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -89,7 +89,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs: 
           artifact: StacksCLI
-          path: $(Build.ArtifactsStagingDirectory)/bin
+          path: $(Build.ArtifactStagingDirectory)/bin
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3
@@ -108,7 +108,7 @@ stages:
           script: |
             task test:integration
         env:
-          BIN_DIR: $(Build.ArtifactsStagingDirectory)/bin
+          BIN_DIR: $(Build.ArtifactStagingDirectory)/bin
           WORKING_DIR: $(Agent.TempDirectory)/projects
 
       # Upload the integration test results
@@ -135,12 +135,12 @@ stages:
           inputs:
             artifact: 'docs'
             patterns: '**/*.pdf'
-            path: $(Build.ArtifactsStagingDirectory)/assets
+            path: $(Build.ArtifactStagingDirectory)/assets
 
         - task: DownloadPipelineArtifact@2
           inputs:
             artifact: 'StacksCLI'
-            path: $(Build.ArtifactsStagingDirectory)/assets
+            path: $(Build.ArtifactStagingDirectory)/assets
             patterns: '!**/*inttest*'
 
         # Install Taskfile for the build to run
@@ -164,4 +164,4 @@ stages:
             API_KEY: $(GITHUB_TOKEN)
             NOTES:
             COMMIT_ID: $(Build.SourceVersion)  
-            ARTIFACTS_DIR: $(Build.ArtifactsStagingDirectory)/assets
+            ARTIFACTS_DIR: $(Build.ArtifactStagingDirectory)/assets

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -66,7 +66,7 @@ stages:
         displayName: Publish Binaries
         inputs:
           pathToPublish: $(Build.SourcesDirectory)/outputs/bin
-          artifactName: StacksCLI
+          artifactName: StacksCLI      
 
       # Upload the documentation
       - task: PublishBuildArtifacts@1
@@ -74,6 +74,48 @@ stages:
         inputs:
           pathToPublish: $(Build.SourcesDirectory)/outputs/docs
           artifactName: docs
+
+  - stage: Integration Tests
+    dependsOn: Build
+    condition: and(succeeded())
+
+    jobs:
+    
+    - job: Execute Functional Tests
+
+      steps:
+
+      # Download the StacksCLI and the integration_tests
+      - task: DownloadPipelineArtifact@2
+        inputs: 
+          artifact: StacksCLI
+          path: $(Build.ArtifactsStagingDirectory)/bin
+
+      # Install Taskfile so that the tests can be run
+      - task: Bash@3
+        displayName: Install Taskfile
+        inputs:
+          targetType: inline
+          script: |
+            wget https://github.com/go-task/task/releases/download/v${{ variables.TaskfileVersion }}/task_linux_amd64.tar.gz -O /tmp/task.tar.gz
+            tar zxf /tmp/task.tar.gz -C /usr/local/bin task           
+
+      # Run the integration tests
+      - task: Bash@3
+        displayName: Build & Test
+        inputs:
+          targetType: inline
+          script: |
+            task test:integration
+        env:
+          BIN_DIR: $(Build.ArtifactsStagingDirectory)/bin
+          WORKING_DIR: $(Agent.TempDirectory)/projects
+
+      # Upload the integration test results
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: $(Build.SourcesDirectory)/outputs/tests/integration_report.xml
 
   - stage: Release
     dependsOn: Build
@@ -99,6 +141,7 @@ stages:
           inputs:
             artifact: 'StacksCLI'
             path: $(Build.ArtifactsStagingDirectory)/assets
+            patterns: '!**/*inttest*'
 
         # Install Taskfile for the build to run
         - task: Bash@3

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -106,6 +106,8 @@ stages:
         inputs:
           targetType: inline
           script: |
+            export GOBIN=$HOME/go/bin
+            export PATH=$PATH:$GOBIN
             task test:integration
         env:
           BIN_DIR: $(Build.ArtifactStagingDirectory)/bin

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -123,7 +123,7 @@ stages:
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: JUnit
-          testResultsFiles: $(Build.SourcesDirectory)/outputs/tests/integration_report.xml
+          testResultsFiles: $(Build.SourcesDirectory)/outputs/tests/integration_test_report.xml
 
   - stage: Release
     dependsOn: Build

--- a/build/azuredevops-taskfile.yml
+++ b/build/azuredevops-taskfile.yml
@@ -75,7 +75,7 @@ stages:
           pathToPublish: $(Build.SourcesDirectory)/outputs/docs
           artifactName: docs
 
-  - stage: Integration Tests
+  - stage: IntegrationTests
     dependsOn: Build
     condition: succeeded()
 

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -68,35 +68,6 @@ func (s *Scaffold) Run() error {
 
 }
 
-// run iterates around all the projects that have been specified and sets up the
-// working directory for each of them
-// func (s *Scaffold) run() error {
-
-// 	pwd, err := os.Getwd()
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	s.Logger.Tracef("Current Dir: %s\n", pwd)
-
-// 	// Iterate around the projects that have been configured
-// 	for _, project := range s.Config.Input.Project {
-
-// 		// Determine the project path
-// 		s.Config.Self.AddPath(project, s.setProjectPath(project.Name))
-// 		s.Logger.Infof("Project path: %s\n", s.Config.Self.GetPath(project))
-// 		s.Logger.Debugf("Project ID: %s", project.GetId())
-
-// 		// create the directory
-// 		err := os.MkdirAll(s.Config.Self.GetPath(project), 0755)
-// 		if err != nil {
-// 			break
-// 		}
-// 	}
-
-// 	return err
-// }
-
 // PerformOperation performs the operation as specified by the settings file for the project
 // It is responsible for performing any template replacements using GoTemplate
 //

--- a/testing/integration/scaffold_args_test.go
+++ b/testing/integration/scaffold_args_test.go
@@ -1,0 +1,147 @@
+// +build integration
+
+package integration
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/amido/stacks-cli/internal/util"
+	// "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+var company = flag.String("company", "MyCompany", "Name of the company")
+var project = flag.String("project", "my-webapi", "Name of the project")
+var projectDir = flag.String("projectdir", ".", "Project Directory")
+var binaryCmd = flag.String("binarycmd", "stacks-cli", "Name and path of the binary to use to run the tests")
+
+// ArgumentTestSuite sets up the suite for checking that the command line args run properly
+type ArgumentSuite struct {
+	suite.Suite
+
+	// set the name of the project to create
+	Project    string
+	ProjectDir string
+
+	// Set the name of the company for which the project is being setup for
+	Company string
+
+	// The name of the command to run
+	BinaryCmd string
+
+	// Cmdoutput to be used for analysis
+	CmdOutput string
+}
+
+// SetupSuite sets up the tests by running the command to test the result from
+func (suite *ArgumentSuite) SetupSuite() {
+
+	// create the command and arguments required for the tests
+	command := suite.BinaryCmd
+	arguments := fmt.Sprintf(`scaffold -A core --company %s --component backend --domain stacks-example.com
+-F dotnet -n %s -p azdo -P aks --tfcontainer mywebapi --tfgroup supporting-group --tfstorage kjh56sdfnjnkjn
+-O webapi --cmdlog -w %s`, suite.Company, suite.Project, suite.ProjectDir)
+
+	// use the util function to split the arguments up and run the command
+	cmd, args := util.BuildCommand(command, arguments)
+
+	// configure the exec command to execute the command
+	out, err := exec.Command(cmd, args...).Output()
+	if err != nil {
+		suite.T().Errorf("Error running command: %s", err.Error())
+	}
+	suite.CmdOutput = string(out)
+
+	// cmdLine.Stdout = os.Stdout
+	// cmdLine.Stderr = os.Stderr
+
+	// execute the command
+	//if err := cmdLine.Run(); err != nil {
+	//	suite.T().Errorf("Error running command: %s", err.Error())
+	//}
+}
+
+// TearDownSuite removes all of the files that have been generated in this suite
+func (suite *ArgumentSuite) TearDownSuite() {
+	err := ClearDir(suite.ProjectDir)
+	if err != nil {
+		suite.T().Errorf("Error tearing down the Argument Suite: %v", err)
+	}
+}
+
+// TestProjectDirExists tests that the project directory has been created properly
+func (suite *ArgumentSuite) TestProjectDirExists() {
+	exists := util.Exists(filepath.Join(suite.ProjectDir, suite.Project))
+	suite.Equal(true, exists)
+}
+
+// TestCmdlogExists ensures that the command log has been created
+func (suite *ArgumentSuite) TestCmdlogExists() {
+	exists := util.Exists("cmdlog.txt")
+	suite.Equal(true, exists)
+}
+
+// TestVariablesFileExists checks that the variable file required for the build pipeline exists
+func (suite *ArgumentSuite) TestVariablesFileExists() {
+	variablesFile := filepath.Join(suite.ProjectDir, suite.Project, "build", "azDevOps", "azure", "azuredevops-vars.yml")
+	exists := util.Exists(variablesFile)
+	suite.Equal(true, exists)
+}
+
+// TestNamespace checks that the source files for the project have been corrected set with the
+// name of the company as supplied on the command line
+// It does this by taking the first directory of the src/api folder and checks that it begins
+// with the specified company name
+func (suite *ArgumentSuite) TestNamespace() {
+	var firstDir string
+
+	basedir := filepath.Join(suite.ProjectDir, suite.Project, "src", "api")
+	files, _ := os.ReadDir(basedir)
+
+	// iterate around the files and get the first directory
+	for _, file := range files {
+		filePath := filepath.Join(basedir, file.Name())
+		info, err := os.Stat(filePath)
+		if err != nil {
+			suite.T().Errorf("Problem analysing file: %v", err)
+		}
+
+		if info.IsDir() {
+			firstDir = file.Name()
+			break
+		}
+	}
+
+	// Check that the dirname begins with %company%
+	pattern := fmt.Sprintf("^%s.*$", suite.Company)
+	re := regexp.MustCompile(pattern)
+	matched := re.MatchString(firstDir)
+
+	suite.Equal(true, matched)
+
+}
+
+// TestRunSuite runs the testify test suite
+// This is being used so that it possible to have a SetupSuite and a TearDown suite so that
+// the necessary commands can be run and then the result checked
+func TestArgumentSuite(t *testing.T) {
+
+	s := new(ArgumentSuite)
+	s.BinaryCmd = *binaryCmd
+	s.Company = *company
+	s.Project = *project
+	s.ProjectDir = *projectDir
+
+	// if the projectDir is . then set to the current dir
+	if s.ProjectDir == "." {
+		s.ProjectDir, _ = os.Getwd()
+	}
+
+	suite.Run(t, s)
+}

--- a/testing/integration/shared.go
+++ b/testing/integration/shared.go
@@ -1,0 +1,30 @@
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ClearDir clears all of the files and folders within the specified
+// directory. This is primarily used by the TearDown function of the test suites
+// This is so that the parent directory does not get removed
+func ClearDir(dir string) error {
+	files, err := filepath.Glob(filepath.Join(dir, "*"))
+
+	if err != nil {
+		return err
+	}
+
+	// iterate around the files that have been found an remove them
+	for _, file := range files {
+		err := os.RemoveAll((file))
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+


### PR DESCRIPTION
Added integration test that tests creating a new project from the command line using just arguments on the command line.

Updated the build pipeline so that the tests are built and pushed as artifacts in the build.
These are then downloaded in a new FunctionalTest phase. The tasks then ensure that the files are executable so they can be run against the built CLI.
