### PR TITLE
Update to handle trunk branch for project

### DIFF
--- a/build/scripts/Set-BuildNumber.ps1
+++ b/build/scripts/Set-BuildNumber.ps1
@@ -13,6 +13,9 @@ param (
     $default = "100.98.99",
 
     [string]
+    [Parameter(Position=0)]
+    [AllowNull()]
+    [AllowEmptyString()]
     # Allow the build number to be passed in
     $number = ""
 )

--- a/configs/.gitkeep
+++ b/configs/.gitkeep
@@ -1,1 +1,0 @@
-Can store sample configs or base

--- a/docs/runtime_config.adoc
+++ b/docs/runtime_config.adoc
@@ -153,7 +153,9 @@ options:
 
 stacks:
   dotnet:
-    webapi: https://github.com/amido/stacks-dotnet
+    webapi: 
+      url: https://github.com/amido/stacks-dotnet
+      trunk: master
 ----
 
 Note that when using the configuration file it is possible to specify multiple projects to be configured. This allows several projects to be setup at the same time, without having to run the command multiple times. Each project will be created within the specified working directory.

--- a/internal/config/static/stacks_frameworks.yml
+++ b/internal/config/static/stacks_frameworks.yml
@@ -1,14 +1,32 @@
 stacks:
   dotnet:
-    webapi: https://github.com/amido/stacks-dotnet
-    cqrs: https://github.com/amido/stacks-dotnet-cqrs
-    events: https://github.com/amido/stacks-dotnet-cqrs-events
+    webapi: 
+      url: https://github.com/amido/stacks-dotnet
+      trunk: master
+    cqrs: 
+      url: https://github.com/amido/stacks-dotnet-cqrs
+      trunk: master
+    events: 
+      url: https://github.com/amido/stacks-dotnet-cqrs-events
+      trunk: master
   java:
-    webapi: https://github.com/amido/stacks-java
-    cqrs: https://github.com/amido/stacks-java-cqrs
-    events: https://github.com/amido/stacks-java-cqrs-events
+    webapi:
+      url: https://github.com/amido/stacks-java
+      trunk: master
+    cqrs:
+      url: https://github.com/amido/stacks-java-cqrs
+      trunk: main
+    events:
+      url: https://github.com/amido/stacks-java-cqrs-events
+      trunk: main
   nodejs:
-    csr: https://github.com/amido/stacks-typescript-csr
-    ssr: https://github.com/amido/stacks-typescript-ssr
+    csr: 
+      url: https://github.com/amido/stacks-typescript-csr
+      trunk: master
+    ssr:
+      url: https://github.com/amido/stacks-typescript-ssr
+      trunk: master
   infra:
-    aks: https://github.com/amido/stacks-infrastructure-aks/
+    aks: 
+      url: https://github.com/amido/stacks-infrastructure-aks/
+      trunk: master

--- a/internal/util/fetch.go
+++ b/internal/util/fetch.go
@@ -9,10 +9,10 @@ import (
 )
 
 // GitClone uses standard network library to fetch a defined commit and avoids bloating the binary
-func GitClone(repoUrl, ref, tmpPath string, token string) (string, error) {
+func GitClone(repoUrl, ref, trunk string, tmpPath string, token string) (string, error) {
 
 	// get the URL to be used to clone the repo from
-	archiveUrl, err := ArchiveUrl(repoUrl, ref, token)
+	archiveUrl, err := ArchiveUrl(repoUrl, ref, trunk, token)
 	if err != nil {
 		return "", err
 	}
@@ -50,13 +50,13 @@ func GitClone(repoUrl, ref, tmpPath string, token string) (string, error) {
 }
 
 // ArchiveUrl returns the archive url for the repo at a given commit hash or branch or v release
-func ArchiveUrl(repoUrl, ref string, token string) (string, error) {
+func ArchiveUrl(repoUrl, ref string, trunk string, token string) (string, error) {
 
 	var zipUrl string
 	var err error
 
 	// get the apiUrl from the method
-	apiUrl := BuildGitHubAPIUrl(repoUrl, ref, false, token)
+	apiUrl := BuildGitHubAPIUrl(repoUrl, ref, trunk, false, token)
 
 	if token == "" {
 		zipUrl = apiUrl
@@ -67,7 +67,7 @@ func ArchiveUrl(repoUrl, ref string, token string) (string, error) {
 
 	// if the zipUrl has not been found then drop back to the archive URL
 	if zipUrl == "" && err == nil {
-		apiUrl = BuildGitHubAPIUrl(repoUrl, ref, true, token)
+		apiUrl = BuildGitHubAPIUrl(repoUrl, ref, trunk, true, token)
 		zipUrl, err = GetGitHubArchiveUrl(apiUrl, token)
 	}
 

--- a/internal/util/github_api.go
+++ b/internal/util/github_api.go
@@ -69,7 +69,7 @@ func GetGitHubArchiveUrl(path string, token string) (string, error) {
 	return result, err
 }
 
-func BuildGitHubAPIUrl(repoUrl string, ref string, archive bool, token string) string {
+func BuildGitHubAPIUrl(repoUrl string, ref string, trunk string, archive bool, token string) string {
 
 	var url string
 
@@ -85,7 +85,7 @@ func BuildGitHubAPIUrl(repoUrl string, ref string, archive bool, token string) s
 	// release of the repository
 	if archive {
 		if ref == "latest" || ref == "" {
-			ref = "master"
+			ref = trunk
 		}
 
 		url = strings.Join([]string{strings.TrimSuffix(repoUrl, ".git"), fmt.Sprintf("archive/%s.zip", ref)}, "/")

--- a/internal/util/github_api_test.go
+++ b/internal/util/github_api_test.go
@@ -14,6 +14,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 	// build test table
 	tables := []struct {
 		ref     string
+		trunk   string
 		test    string
 		msg     string
 		archive bool
@@ -21,6 +22,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 	}{
 		{
 			"",
+			"master",
 			"https://api.github.com/repos/amido/stacks-dotnet/releases/latest",
 			"An empty ref should return the latest release URL",
 			false,
@@ -28,6 +30,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 		},
 		{
 			"",
+			"master",
 			fmt.Sprintf("%s/archive/master.zip", repoUrl),
 			"An empty ref with no token should return the latest release URL using the archive URL",
 			false,
@@ -35,6 +38,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 		},
 		{
 			"latest",
+			"",
 			"https://api.github.com/repos/amido/stacks-dotnet/releases/latest",
 			"Specifying latest ref should return the latest release URL",
 			false,
@@ -42,6 +46,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 		},
 		{
 			"v3.0.232",
+			"",
 			fmt.Sprintf("%s/archive/v3.0.232.zip", repoUrl),
 			"A specified tag with no token should return the release for that tag using the archive URL",
 			false,
@@ -49,6 +54,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 		},
 		{
 			"v3.0.232",
+			"",
 			"https://api.github.com/repos/amido/stacks-dotnet/releases/tags/v3.0.232",
 			"A specified tag should return the release for that tag",
 			false,
@@ -56,6 +62,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 		},
 		{
 			"feature/dotnet-6",
+			"",
 			fmt.Sprintf("%s/archive/feature/dotnet-6.zip", repoUrl),
 			"A branch can be specified if the archive flag is used",
 			true,
@@ -67,7 +74,7 @@ func TestBuildGitHubAPIUrl(t *testing.T) {
 	for _, table := range tables {
 
 		// get the ghUrl from the method
-		ghUrl := BuildGitHubAPIUrl(repoUrl, table.ref, table.archive, table.token)
+		ghUrl := BuildGitHubAPIUrl(repoUrl, table.ref, table.trunk, table.archive, table.token)
 
 		if ghUrl != table.test {
 			t.Error(table.msg)

--- a/pkg/config/stacks.go
+++ b/pkg/config/stacks.go
@@ -8,30 +8,35 @@ type Stacks struct {
 }
 
 type Dotnet struct {
-	Webapi string `mapstructure:"webapi"`
-	CQRS   string `mapstructure:"cqrs"`
-	Events string `mapstructure:"events"`
+	Webapi RepoInfo `mapstructure:"webapi"`
+	CQRS   RepoInfo `mapstructure:"cqrs"`
+	Events RepoInfo `mapstructure:"events"`
 }
 
 type Java struct {
-	Webapi string `mapstructure:"webapi"`
-	CQRS   string `mapstructure:"cqrs"`
-	Events string `mapstructure:"events"`
+	Webapi RepoInfo `mapstructure:"webapi"`
+	CQRS   RepoInfo `mapstructure:"cqrs"`
+	Events RepoInfo `mapstructure:"events"`
 }
 
 type NodeJS struct {
-	CSR string `mapstructure:"csr"`
-	SSR string `mapstructure:"ssr"`
+	CSR RepoInfo `mapstructure:"csr"`
+	SSR RepoInfo `mapstructure:"ssr"`
 }
 
 type Infra struct {
-	AKS string `mapstructure:"aks"`
+	AKS RepoInfo `mapstructure:"aks"`
+}
+
+type RepoInfo struct {
+	URL   string `mapstructure:"url"`
+	Trunk string `mapstructure:"trunk"`
 }
 
 // GetSrcURLMap returns a map of the source control repositores
-func (stacks *Stacks) GetSrcURLMap() map[string]string {
+func (stacks *Stacks) GetSrcURLMap() map[string]RepoInfo {
 
-	srcUrls := map[string]string{
+	srcUrls := map[string]RepoInfo{
 		"dotnet_webapi": stacks.Dotnet.Webapi,
 		"dotnet_cqrs":   stacks.Dotnet.CQRS,
 		"dotnet_events": stacks.Dotnet.Events,
@@ -46,7 +51,7 @@ func (stacks *Stacks) GetSrcURLMap() map[string]string {
 	return srcUrls
 }
 
-func (stacks *Stacks) GetSrcURL(key string) string {
+func (stacks *Stacks) GetSrcURL(key string) RepoInfo {
 	srcUrls := stacks.GetSrcURLMap()
 	return srcUrls[key]
 }

--- a/pkg/config/stacks_test.go
+++ b/pkg/config/stacks_test.go
@@ -29,7 +29,9 @@ project:
 
 stacks:
   dotnet:
-    webapi: https://github.com/amido/stacks-dotnet-newfeature
+    webapi:
+      url: https://github.com/amido/stacks-dotnet-newfeature
+      trunk: main
 `)
 
 func setupTestCase(t *testing.T, configuration []byte) (func(t *testing.T), string) {
@@ -85,14 +87,14 @@ func TestDefaultSrcUrlMap(t *testing.T) {
 	// get the src URL map
 	srcURLs := config.Input.Stacks.GetSrcURLMap()
 
-	assert.Equal(t, "https://github.com/amido/stacks-dotnet", srcURLs["dotnet_webapi"])
-	assert.Equal(t, "https://github.com/amido/stacks-dotnet-cqrs", srcURLs["dotnet_cqrs"])
-	assert.Equal(t, "https://github.com/amido/stacks-dotnet-cqrs-events", srcURLs["dotnet_events"])
-	assert.Equal(t, "https://github.com/amido/stacks-java", srcURLs["java_webapi"])
-	assert.Equal(t, "https://github.com/amido/stacks-java-cqrs", srcURLs["java_cqrs"])
-	assert.Equal(t, "https://github.com/amido/stacks-java-cqrs-events", srcURLs["java_events"])
-	assert.Equal(t, "https://github.com/amido/stacks-typescript-csr", srcURLs["nodejs_csr"])
-	assert.Equal(t, "https://github.com/amido/stacks-typescript-ssr", srcURLs["nodejs_ssr"])
+	assert.Equal(t, "https://github.com/amido/stacks-dotnet", srcURLs["dotnet_webapi"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-dotnet-cqrs", srcURLs["dotnet_cqrs"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-dotnet-cqrs-events", srcURLs["dotnet_events"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-java", srcURLs["java_webapi"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-java-cqrs", srcURLs["java_cqrs"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-java-cqrs-events", srcURLs["java_events"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-typescript-csr", srcURLs["nodejs_csr"].URL)
+	assert.Equal(t, "https://github.com/amido/stacks-typescript-ssr", srcURLs["nodejs_ssr"].URL)
 }
 
 func TestSrcUrlMap(t *testing.T) {
@@ -125,5 +127,5 @@ func TestSrcUrlMap(t *testing.T) {
 	// get the src URL map
 	srcURLs := config.Input.Stacks.GetSrcURLMap()
 
-	assert.Equal(t, "https://github.com/amido/stacks-dotnet-newfeature", srcURLs["dotnet_webapi"])
+	assert.Equal(t, "https://github.com/amido/stacks-dotnet-newfeature", srcURLs["dotnet_webapi"].URL)
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -183,16 +183,16 @@ func (s *Scaffold) processProject(project config.Project) {
 
 	// Get the URL for the repository to download
 	key := project.Framework.GetMapKey()
-	srcUrl := s.Config.Input.Stacks.GetSrcURL(key)
+	repoInfo := s.Config.Input.Stacks.GetSrcURL(key)
 
 	// if the URL is empty, emit error message and state why this might be the case
-	if srcUrl == "" {
+	if repoInfo == (config.RepoInfo{}) {
 		s.Logger.Errorf(`The URL for the specified framework option, %s, is empty. Have you specified the correct framework option?`, project.Framework.Option)
 		return
 	}
 
 	// check that the URL is valid, if not skip this project and move onto the next one
-	_, err = url.ParseRequestURI(srcUrl)
+	_, err = url.ParseRequestURI(repoInfo.URL)
 	if err != nil {
 		s.Logger.Errorf("Unable to download framework option as URL is invalid: %s", err.Error())
 		return
@@ -200,8 +200,9 @@ func (s *Scaffold) processProject(project config.Project) {
 
 	s.Logger.Infof("Retrieving framework option: %s", key)
 	dir, err := util.GitClone(
-		srcUrl,
+		repoInfo.URL,
 		project.Framework.Version,
+		repoInfo.Trunk,
 		s.Config.Input.Directory.TempDir,
 		s.Config.Input.Options.Token,
 	)

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -50,7 +50,7 @@ tasks:
   buildnumber:
     context: buildenv
     command:
-      - /app/build/scripts/Set-BuildNumber.ps1 -number $BUILDNUMBER
+      - /app/build/scripts/Set-BuildNumber.ps1 $BUILDNUMBER
     exportAs: BUILDNUMBER
 
   clean:


### PR DESCRIPTION
So that different branches can be set as the trunk branch, to handle the `latest` tag when using the archive URL to do download the package, the CLI has been updated to allow this to be set.

The new structure expands on the Stacks frameworks and now includes a `URL` and a `Trunk` object, e.g.:

```
stacks:
   dotnet:
       webapi:
           url: https://github.com/amido/stacks-dotnet
           trunk: master
```

This baked into the CLI at build time, but can be overridden at runtime using a configuration file.