### PR TITLE
Fixes after Deep Dive demo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+[XXXX-<Title> - Please use the Work Item number and Title as PR Name, not subtasks]
+
+#### 📲 What
+
+A description of the change.
+
+#### 🤔 Why
+		
+Why it's needed, background context.
+		
+#### 🛠 How
+		
+More in-depth discussion of the change or implementation.
+
+#### 👀 Evidence
+		
+Screenshots / external resources / links / etc.
+Link to documentation updated with changes impacted in the PR
+		 
+#### 🕵️ How to test
+
+Notes for QA
+
+#### ✅ Acceptance criteria Checklist
+
+- [ ] Code peer reviewed?
+- [ ] Documentation has been updated to reflect the changes?
+- [ ] Passing all automated tests, including a successful deployment?
+- [ ] Passing any exploratory testing?
+- [ ] Rebased/merged with latest changes from development and re-tested?
+- [ ] Meeting the Coding Standards?

--- a/internal/config/static/static.go
+++ b/internal/config/static/static.go
@@ -41,7 +41,7 @@ func Config(key string) []byte {
 func FrameworkCommands(framework string) []string {
 	commands := map[string][]string{
 		"dotnet": {"dotnet", "git"},
-		"java":   {"java", "mvn", "git"},
+		"java":   {"java", "git"},
 	}
 
 	return commands[framework]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -256,7 +256,7 @@ func (config *Config) WriteCmdLog(path string, cmd string) error {
 }
 
 // ExecuteCommand executes the command and arguments that have been supplied to the function
-func (config *Config) ExecuteCommand(path string, logger *logrus.Logger, command string, arguments string, show bool) (string, error) {
+func (config *Config) ExecuteCommand(path string, logger *logrus.Logger, command string, arguments string, show bool, force bool) (string, error) {
 
 	var result bytes.Buffer
 	var err error
@@ -307,7 +307,9 @@ func (config *Config) ExecuteCommand(path string, logger *logrus.Logger, command
 	}
 
 	// only run the command if not in dryrun mode
-	if !config.IsDryRun() {
+	// or if the force option has been set, this is for non-destructive commands such as checking the version of
+	// a command
+	if !config.IsDryRun() || force {
 		if err = cmdLine.Run(); err != nil {
 			logger.Errorf("Error running command: %s", err.Error())
 			return strings.TrimSpace(result.String()), err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -616,7 +616,7 @@ func TestExecuteCommand(t *testing.T) {
 	arguments := "HelloWorld!"
 
 	// call the ExecuteCommand to run the command and get the result
-	result, err := config.ExecuteCommand(dir, logger, command, arguments, false)
+	result, err := config.ExecuteCommand(dir, logger, command, arguments, false, false)
 
 	// perform the necessary tests
 	assert.Equal(t, nil, err)

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -118,7 +118,7 @@ func (s *Settings) CheckCommandVersions(config *Config, logger *logrus.Logger, p
 			continue
 		}
 
-		result, err := config.ExecuteCommand(path, logger, versionCmd, versionArgs, false)
+		result, err := config.ExecuteCommand(path, logger, versionCmd, versionArgs, false, true)
 
 		// check for errors
 		if err != nil {

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -131,7 +131,7 @@ func (s *Scaffold) PerformOperation(operation config.Operation, project *config.
 		arguments = os.ExpandEnv(arguments)
 
 		// Execute the command and check that it worked
-		_, err = s.Config.ExecuteCommand(path, s.Logger, command, arguments, false)
+		_, err = s.Config.ExecuteCommand(path, s.Logger, command, arguments, false, false)
 		if err != nil {
 			s.Logger.Errorf("Issue running command: %s", err.Error())
 		}

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -54,6 +54,7 @@ tasks:
     exportAs: BUILDNUMBER
 
   clean:
+    context: buildenv
     description: Clean old builds
     command:
       - rm -rf outputs


### PR DESCRIPTION
#### 📲 What

Updated the CLI to address two issues:

- Maven was being checked for when running a Java framework project
- When DryRun was enabled the check for the version of the framework was not being performed

#### 🤔 Why
		
When scaffolding a Java project the CLI was checking that Maven, `mvn`, was installed. However the project itself will wrap `mvn` so it does not need to installed locally.

When the `dryrun` option was enabled the version check on the framework would not be performed. This meant that the CLI would crash as it was trying to check a version number against a null string.
		
#### 🛠 How
		
Removed the `mvn` command check for a java project.

Added a `force` parameter to the `ExecuteCommand` method to allow the version check to override DryRun option if it has been set. This has been done as checking the version of the framework is a non destructive operation.

#### 👀 Evidence
		
CLI does not crash now that the framework command can be executed.
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
