### PR TITLE
Corrected issue where a template token can cause a panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ vendor/
 
 local/
 outputs/
+inttest/
 
 build/tests
 

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -138,7 +138,7 @@ stages:
             patterns: '**/*.pdf'
             path: $(Build.SourcesDirectory)/outputs/assets
 
-        - task: DownloadPipelineArtifact@1
+        - task: DownloadPipelineArtifact@2
           inputs:
             artifact: 'StacksCLI'
             path: $(Build.SourcesDirectory)/outputs/assets

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -100,7 +100,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !*inttest*
+            !(**/*inttest*)
 
 
       # Install Taskfile so that the tests can be run

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -88,12 +88,12 @@ stages:
           artifact: StacksCLI
           path: $(Build.SourcesDirectory)/outputs/bin
 
-      - task: DownloadPipelineArtifact@2
+      - task: DownloadPipelineArtifact@1
         inputs:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !**/stacks-cli-@(darwin|linux|windows)-inttest*
+            !**/*inttest*
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3
@@ -145,12 +145,12 @@ stages:
             patterns: '**/*.pdf'
             path: $(Build.SourcesDirectory)/outputs/assets
 
-        - task: DownloadPipelineArtifact@2
+        - task: DownloadPipelineArtifact@1
           inputs:
             artifact: 'StacksCLI'
             path: $(Build.SourcesDirectory)/outputs/assets
             patterns: |
-              - "!**/stacks-cli-@(darwin|linux|windows)-inttest*"
+              !**/*inttest*
 
         # Install Taskfile for the build to run
         - task: Bash@3

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -100,7 +100,8 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !(**/*inttest*)
+            **
+            !**/*inttest*
 
 
       # Install Taskfile so that the tests can be run

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -142,7 +142,8 @@ stages:
           inputs:
             artifact: 'StacksCLI'
             path: $(Build.SourcesDirectory)/outputs/assets
-            patterns: '!**/*inttest*'
+            patterns: |
+              - "!**/stacks-cli-@(darwin|linux|windows)-inttest*"
 
         # Install Taskfile for the build to run
         - task: Bash@3

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -88,22 +88,6 @@ stages:
           artifact: StacksCLI
           path: $(Build.SourcesDirectory)/outputs/bin
 
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifact: 'StacksCLI'
-          path: $(Build.SourcesDirectory)/outputs/assets
-          patterns: |
-            **/*inttest*
-
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifact: 'StacksCLI'
-          path: $(Build.SourcesDirectory)/outputs/assets
-          patterns: |
-            **
-            !**/*inttest*
-
-
       # Install Taskfile so that the tests can be run
       - task: Bash@3
         displayName: Install Taskctl
@@ -159,6 +143,7 @@ stages:
             artifact: 'StacksCLI'
             path: $(Build.SourcesDirectory)/outputs/assets
             patterns: |
+              **
               !**/*inttest*
 
         # Install Taskfile for the build to run

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -88,6 +88,13 @@ stages:
           artifact: StacksCLI
           path: $(Build.SourcesDirectory)/outputs/bin
 
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: 'StacksCLI'
+          path: $(Build.SourcesDirectory)/outputs/assets
+          patterns: |
+            - "!**/stacks-cli-@(darwin|linux|windows)-inttest*"          
+
       # Install Taskfile so that the tests can be run
       - task: Bash@3
         displayName: Install Taskctl

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -93,7 +93,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            - "!**/*inttest*"          
+            !**/stacks-cli-@(darwin|linux|windows)-inttest*
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -100,7 +100,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !+**/*inttest*
+            !*inttest*
 
 
       # Install Taskfile so that the tests can be run

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -93,7 +93,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !**/*inttest*
+            **/*inttest*
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -93,7 +93,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            - "!**/stacks-cli-@(darwin|linux|windows)-inttest*"          
+            - "!**/*inttest*"          
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -100,7 +100,7 @@ stages:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
-            !**/*inttest*
+            !+**/*inttest*
 
 
       # Install Taskfile so that the tests can be run

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -88,12 +88,20 @@ stages:
           artifact: StacksCLI
           path: $(Build.SourcesDirectory)/outputs/bin
 
-      - task: DownloadPipelineArtifact@1
+      - task: DownloadPipelineArtifact@2
         inputs:
           artifact: 'StacksCLI'
           path: $(Build.SourcesDirectory)/outputs/assets
           patterns: |
             **/*inttest*
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: 'StacksCLI'
+          path: $(Build.SourcesDirectory)/outputs/assets
+          patterns: |
+            !**/*inttest*
+
 
       # Install Taskfile so that the tests can be run
       - task: Bash@3

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -40,7 +40,7 @@ contexts:
         - ${PWD}:/app
         - -w
         - /app
-        - amidostacks/runner-pwsh-asciidoctor:0.39.7-main
+        - amidostacks/runner-pwsh-asciidoctor:0.3.97-main
         - pwsh
         - -NoProfile
         - -Command        

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -25,7 +25,7 @@ contexts:
         - ${PWD}:/app
         - -w
         - /app
-        - russellseymour/dotnet-git:6
+        - amidostacks/runner-pwsh-dotnet:0.3.62-kubectl
         - pwsh
         - -NoProfile
         - -Command        
@@ -40,7 +40,7 @@ contexts:
         - ${PWD}:/app
         - -w
         - /app
-        - russellseymour/pandoc-asciidoctor
+        - amidostacks/runner-pwsh-asciidoctor:0.39.7-main
         - pwsh
         - -NoProfile
         - -Command        

--- a/internal/util/dotnet_sdk_version.go
+++ b/internal/util/dotnet_sdk_version.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// DotnetSDKVersion returns th required Dotnet SDK version from the specified file
+func DotnetSDKVersion(file string) (string, error) {
+
+	// declare variables
+	var err error
+	var jsonStr []byte
+	var sdkGlobal map[string]interface{}
+
+	// check that the file exists
+	if Exists(file) {
+
+		// read the contents of the file into a map
+		jsonStr, err = ioutil.ReadFile(file)
+
+		if err != nil {
+			return "", err
+		}
+	} else {
+		jsonStr = []byte(file)
+	}
+
+	json.Unmarshal(jsonStr, &sdkGlobal)
+
+	res, _ := NestedMapLookup(sdkGlobal, "sdk", "version")
+
+	result := ""
+	if res != nil {
+		result = fmt.Sprintf("%v", res)
+	}
+	return result, err
+}

--- a/internal/util/dotnet_sdk_version_test.go
+++ b/internal/util/dotnet_sdk_version_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDotnetSDKVersionWithString(t *testing.T) {
+
+	// create test table to iterate over to check the dotnet version
+	tables := []struct {
+		sdk  string
+		test string
+		msg  string
+	}{
+		{
+			`{"sdk": {"version": "6.0.200"}}`,
+			"6.0.200",
+			"Version should be 6.0.200: %s",
+		},
+	}
+
+	// iterate around the tests tables and perform the tests
+	for _, table := range tables {
+
+		version, _ := DotnetSDKVersion(table.sdk)
+
+		if version != table.test {
+			t.Errorf(table.msg, version)
+		}
+	}
+}
+
+func TestDotnetSDKVersionFromFile(t *testing.T) {
+
+	// create test able with the name of the file and the content and
+	// the expected result of the test
+	tables := []struct {
+		filename string
+		content  string
+		test     string
+		msg      string
+	}{
+		{
+			"global.json",
+			`{"sdk": {"version": "6.0.200"}}`,
+			"6.0.200",
+			"Version should be 6.0.200: %s",
+		},
+	}
+
+	// get the dir that the file should be written out to
+	dir := t.TempDir()
+
+	// iterate around the tables
+	for _, table := range tables {
+
+		// determine the path to the file
+		file := filepath.Join(dir, table.filename)
+
+		// create a file with the content in the table and the filename
+		if err := os.WriteFile(file, []byte(table.content), 0666); err != nil {
+			t.Fatalf("Unable to create '%s' file: %s", file, err.Error())
+		}
+
+		version, _ := DotnetSDKVersion(file)
+
+		if version != table.test {
+			t.Errorf(table.msg, version)
+		}
+	}
+}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -100,7 +101,9 @@ func Copy(srcFile, dstFile string) error {
 }
 
 func Exists(filePath string) bool {
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+	_, err := os.Stat(filePath)
+
+	if errors.Is(err, os.ErrNotExist) || err != nil {
 		return false
 	}
 

--- a/internal/util/nested_map_lookup.go
+++ b/internal/util/nested_map_lookup.go
@@ -1,0 +1,29 @@
+package util
+
+import "fmt"
+
+// NestedMapLookup
+// m:  a map from strings to other maps or values, of arbitrary depth
+// ks: successive keys to reach an internal or leaf node (variadic)
+// If an internal node is reached, will return the internal map
+//
+// Returns: (Exactly one of these will be nil)
+// rval: the target node (if found)
+// err:  an error created by fmt.Errorf
+//
+func NestedMapLookup(m map[string]interface{}, ks ...string) (rval interface{}, err error) {
+	var ok bool
+
+	if len(ks) == 0 { // degenerate input
+		return nil, fmt.Errorf("NestedMapLookup needs at least one key")
+	}
+	if rval, ok = m[ks[0]]; !ok {
+		return nil, fmt.Errorf("key not found; remaining keys: %v", ks)
+	} else if len(ks) == 1 { // we've reached the final key
+		return rval, nil
+	} else if m, ok = rval.(map[string]interface{}); !ok {
+		return nil, fmt.Errorf("malformed structure at %#v", rval)
+	} else { // 1+ more keys
+		return NestedMapLookup(m, ks[1:]...)
+	}
+}

--- a/internal/util/nested_map_lookup_test.go
+++ b/internal/util/nested_map_lookup_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestNestedMapLookup ensures that a string of JOSN can be turned into a map
+// and values retrieved from it
+func TestNestedMapLookup(t *testing.T) {
+
+	// create a set of tests to run
+	tables := []struct {
+		jsonStr   string
+		test      string
+		testError string
+		ks        []string
+		msg       string
+		msgError  string
+	}{
+		{
+			`{"name": "foo"}`,
+			"foo",
+			"",
+			[]string{"name"},
+			"Actual value is not correct: %s != %s",
+			"No error was expected",
+		},
+		{
+			`{"name": "foo"}`,
+			"",
+			"needs at least one key",
+			[]string{},
+			"No value should be returned",
+			"Expected error was not received",
+		},
+		{
+			`{"name": "foo"}`,
+			"",
+			"key not found",
+			[]string{"address"},
+			"No value should be returned",
+			"Expected error was not received",
+		},
+		{
+			`{"profile": {"firstname": "foo", "lastname": "bar"}}`,
+			"bar",
+			"",
+			[]string{"profile", "lastname"},
+			"Actual value is not correct: %s != %s",
+			"No error was expected",
+		},
+	}
+
+	// iterate around the tables
+	for _, table := range tables {
+
+		// declare the map that the data needs to be put into
+		var data map[string]interface{}
+		var result string
+
+		// unmarshal the JSON str into data
+		json.Unmarshal([]byte(table.jsonStr), &data)
+
+		// get the result from the lookup in the nested search
+		res, err := NestedMapLookup(data, table.ks...)
+
+		if res != nil {
+			result = fmt.Sprintf("%v", res)
+		}
+
+		if result != table.test {
+			t.Errorf(table.msg, result, table.test)
+		}
+
+		if err != nil && strings.Contains(err.Error(), table.testError) == false {
+			t.Error(table.msgError)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,7 +159,7 @@ func (config *Config) WriteVariablesFile(project *Project, pipelineSettings Pipe
 	}
 
 	// render the variable file
-	rendered, err := config.RenderTemplate(variableTemplate, replacements)
+	rendered, err := config.RenderTemplate(filepath.Base(variableFile), variableTemplate, replacements)
 
 	if err != nil {
 		return fmt.Sprintf("Problem rendering variable template file: %s", err.Error()), err
@@ -184,18 +184,21 @@ func (config *Config) WriteVariablesFile(project *Project, pipelineSettings Pipe
 
 // renderTemplate takes any string and attempts to replace items in it based
 // on the values in the supplied Input object
-func (config *Config) RenderTemplate(tmpl string, input Replacements) (string, error) {
+func (config *Config) RenderTemplate(name string, tmpl string, input Replacements) (string, error) {
 
 	// declare var to hold the rendered string
 	var rendered bytes.Buffer
 
 	// create an object of the template
-	t := template.Must(
-		template.New("").Parse(tmpl),
-	)
+	// if it fails then return with an error
+	t, err := template.New(name).Parse(tmpl)
+
+	if err != nil {
+		return "", err
+	}
 
 	// render the template into the variable
-	err := t.Execute(&rendered, input)
+	err = t.Execute(&rendered, input)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,7 +66,7 @@ func TestNonTemplateString(t *testing.T) {
 	replacements.Input = cfg.Input
 
 	// attempt to render the template
-	rendered, err := cfg.RenderTemplate(tmpl, replacements)
+	rendered, err := cfg.RenderTemplate("string", tmpl, replacements)
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, tmpl, rendered)
@@ -90,7 +90,7 @@ func TestTemplateString(t *testing.T) {
 	tmpl := "Company: {{ .Input.Business.Company }}; Domain: {{ .Input.Business.Domain }}"
 
 	// attempt to render the template
-	rendered, err := cfg.RenderTemplate(tmpl, replacements)
+	rendered, err := cfg.RenderTemplate("string", tmpl, replacements)
 
 	// define the expected value
 	expected := "Company: my-company; Domain: website"

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -121,7 +121,7 @@ func (s *Scaffold) PerformOperation(operation config.Operation, project *config.
 		command = operation.Command
 
 		// run the arguments that have been specified through the template engine
-		arguments, err := s.Config.RenderTemplate(operation.Arguments, replacements)
+		arguments, err := s.Config.RenderTemplate("arguments", operation.Arguments, replacements)
 		if err != nil {
 			s.Logger.Errorf("Error resolving template: %s", err.Error())
 			return err

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -236,7 +236,7 @@ func (s *Scaffold) processProject(project config.Project) {
 
 	// check to see if any framework commands have been set and check the
 	// version if they have
-	incorrect := project.Settings.CheckCommandVersions(s.Config, s.Logger, project.Directory.WorkingDir)
+	incorrect := project.Settings.CheckCommandVersions(s.Config, s.Logger, project.Directory.WorkingDir, project.Directory.TempDir)
 	if len(incorrect) > 0 {
 
 		var parts []string

--- a/testing/integration/base_integration.go
+++ b/testing/integration/base_integration.go
@@ -230,6 +230,15 @@ func (suite *BaseIntegration) RunCommand(command string, arguments string, ignor
 	// use the util function to split the arguments
 	cmd, args := util.BuildCommand(command, arguments)
 
+	// write out the command thst ius being run
+	cmdlogFile := filepath.Join(suite.ProjectDir, "cmdlog.txt")
+
+	err := ioutil.WriteFile(cmdlogFile, []byte(fmt.Sprintf("%s %s", command, arguments)), 0666)
+
+	if err != nil {
+		suite.T().Fatalf("Error writing command to log file: %s", err.Error())
+	}
+
 	// configure the exec command to execute the command
 	out, err := exec.Command(cmd, args...).Output()
 	if err != nil && !ignore {

--- a/testing/integration/scaffold_args_test.go
+++ b/testing/integration/scaffold_args_test.go
@@ -107,7 +107,7 @@ func (suite *ArgsSuite) TestProject() {
 
 	// ensure that the devops variable template exists
 	suite.T().Run("Azure DevOps variable template file exist", func(t *testing.T) {
-		path := filepath.Join(suite.ProjectPath, "build", "azDevOps", "azure", "azuredevops-vars.yml")
+		path := filepath.Join(suite.ProjectPath, "build", "azDevOps", "azure", "air-api-vars.yml")
 		exists := util.Exists(path)
 
 		suite.Assert.Equal(true, exists, "Project should exist: %s", "Azure DevOps variable template file should exist: %s", path)

--- a/testing/integration/scaffold_configfile_test.go
+++ b/testing/integration/scaffold_configfile_test.go
@@ -39,6 +39,7 @@ func (suite *ConfigFileSuite) SetupSuite() {
 
 // TearDownSuite removes all of the files that have been generated in this suite
 func (suite *ConfigFileSuite) TearDownSuite() {
+	return
 	err := suite.ClearDir(suite.ProjectDir)
 	if err != nil {
 		fmt.Printf("Error tearing down the ConfigFileSuite: %v", err)
@@ -81,7 +82,7 @@ func (suite *ConfigFileSuite) TestProject1() {
 
 	// ensure that the devops variable template exists
 	suite.T().Run("Azure DevOps variable template file exist", func(t *testing.T) {
-		path := filepath.Join(suite.ProjectPath1, "build", "azDevOps", "azure", "azuredevops-vars.yml")
+		path := filepath.Join(suite.ProjectPath1, "build", "azDevOps", "azure", "air-api-vars.yml")
 		exists := util.Exists(path)
 
 		suite.Assert.Equal(true, exists, "Azure DevOps variable template file should exist: %s", path)
@@ -132,6 +133,8 @@ func (suite *ConfigFileSuite) TestProject1() {
 				suite.T().Fatalf("Problem analysing file: %v", err)
 			}
 
+			suite.T().Log(fmt.Sprintf("%s", file.Name()))
+
 			if info.IsDir() {
 				firstDir = file.Name()
 				break
@@ -160,7 +163,7 @@ func (suite *ConfigFileSuite) TestProject2() {
 
 	// ensure that the devops variable template exists
 	suite.T().Run("Azure DevOps variable template file exist", func(t *testing.T) {
-		path := filepath.Join(suite.ProjectPath2, "build", "azDevOps", "azure", "azuredevops-vars.yml")
+		path := filepath.Join(suite.ProjectPath2, "build", "azDevOps", "azure", "air-api-vars.yml")
 		exists := util.Exists(path)
 
 		suite.Assert.Equal(true, exists, "Azure DevOps variable template file should exist: %s", path)


### PR DESCRIPTION
#### 📲 What

Protected against situations where the template file contains the Golang template delimiters of `{{`, `}}` as can be the case with Azure DevOps variables, if the variable is a compile time variable.

Modified the download pattern for creating releases as for some reason this was not downloading binary files for a release.

When Stacks CLI checked for the version of .NET, for example, it would satisfy the constraints in the `stackscli.yml` file but if the project contained `global.json` file with the version of the SDK to use, it would cause errors if the versions do not match.

Fixed issue whereby a directory was trying to be uploaded to the release

Support for the Apple M1 chip

#### 🤔 Why
		
Clashing tokens with the Golang templating language

Artifacts are not being downloaded properly for the GitHub release.

When running `dotnet` the `global.json` file is read, if it exists, and the versions do not match it will throw an error. This was not caught properly in the CLI and a lot of error codes would be displayed.

Although MacOS was supported, the new M1 chip (arm64) was not being built
		
#### 🛠 How
		
Ensured that if a clash is found then the program will exit gracefully.

The pattern for downloading artifacts was incorrect. It needs to specify all of the files on one line and then on the next the ones that are not required, in this case the `inttest` files.

The CLI will now check to see of the `global.json` file exists and read it. It will do a check to make sure that the version of dotnet satisfies this requirement. This is an additional check on top of the version contraint.

As the Apple M1 chip is now being shipped the scripts have been updated to create a binary for the arm64 arch for Darwin.

#### Evidence

All 8 binaries are now being downloaded correctly for a release.
